### PR TITLE
Fix Insecure Deserialization Vulnerability in toObject Method

### DIFF
--- a/y9-module-jodconverter/risenet-y9boot-webapp-jodconverter/src/main/java/net/risesoft/service/cache/impl/CacheServiceRocksDBImpl.java
+++ b/y9-module-jodconverter/risenet-y9boot-webapp-jodconverter/src/main/java/net/risesoft/service/cache/impl/CacheServiceRocksDBImpl.java
@@ -261,7 +261,8 @@ public class CacheServiceRocksDBImpl implements CacheService {
     private Object toObject(byte[] bytes) throws IOException, ClassNotFoundException {
         Object obj;
         ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
-        ObjectInputStream ois = new ObjectInputStream(bis);
+        ValidatingObjectInputStream ois = new ValidatingObjectInputStream(bis); {
+        ois.accept(LinkedList.class, LogMutation.class, HashMap.class, String.class);
         obj = ois.readObject();
         ois.close();
         bis.close();


### PR DESCRIPTION
Summary
This PR addresses a critical security vulnerability in the toObject method which performs unrestricted deserialization of objects, potentially allowing remote code execution if the serialized data comes from untrusted sources.

Description
The current implementation uses standard ObjectInputStream without any class validation, which is vulnerable to deserialization attacks. This change implements proper validation by using Apache Commons IO's ValidatingObjectInputStream and explicitly whitelisting allowed classes.

References
https://github.com/apache/hadoop/commit/5e2f4339fadc88f20543915fc9b0aaeaf4f9e7bf
https://nvd.nist.gov/vuln/detail/CVE-2022-25168